### PR TITLE
fix: fix muted chat counter

### DIFF
--- a/recipes/whatsapp/webview.js
+++ b/recipes/whatsapp/webview.js
@@ -26,10 +26,10 @@ module.exports = Ferdium => {
         console.log(event)
         for (const chat of event.target.result) {
           if (chat.unreadCount > 0) {
-            if (chat.muteExpiration > 0) {
-              unreadMutedCount += chat.unreadCount;
-            } else {
+            if (chat.muteExpiration == 0) {
               unreadCount += chat.unreadCount;
+            } else {
+              unreadMutedCount += chat.unreadCount;
             }
           }
         }


### PR DESCRIPTION
The chat.muteExpiration attribute can take multiple values : -1 (unlimited mute), 0 (unmuted), and a bigger value representing its expiration in seconds.

Current, we check if chat.muteExpiration > 0 to add to the muted counter. Thus, we add messages with -1 expiration to the unmuted message counter.

In this respect, it seems much simpler to just check if chat.muteExpiration is equal to 0, in which case it's not muted, and consider every other value a muted chat.